### PR TITLE
Change LIBSBXML return values to LIBLX opens.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1110,9 +1110,9 @@ else(UNIX)
         SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 
         # Provide an easy way to use Visual Leak Detector (https://vld.codeplex.com)
-    option(LIBSBML_USE_VLD "When running debug builds with MSVC use Visual Leak Detector." OFF)
-    mark_as_advanced(LIBSBML_USE_VLD)
-    if (LIBSBML_USE_VLD)
+    option(LIBLX_USE_VLD "When running debug builds with MSVC use Visual Leak Detector." OFF)
+    mark_as_advanced(LIBLX_USE_VLD)
+    if (LIBLX_USE_VLD)
           find_path(VLD_INCLUDE_DIR
             NAMES vld.h
             PATHS ${LIBSBML_DEPENDENCY_DIR}/include
@@ -1126,9 +1126,9 @@ else(UNIX)
         include_directories(${VLD_INCLUDE_DIR})
       endif()
 
-      add_definitions( -DLIBSBML_USE_VLD)
+      add_definitions( -DLIBLX_USE_VLD)
 
-    endif (LIBSBML_USE_VLD)
+    endif (LIBLX_USE_VLD)
 
     # CMake no longer creates PDB files for static libraries after 2.8.11
     # so we store debug information in the object files instead

--- a/src/liblx/xml/XMLAttributes.cpp
+++ b/src/liblx/xml/XMLAttributes.cpp
@@ -156,7 +156,7 @@ XMLAttributes::add (const std::string& name,
     mValues[(size_t)index] = value;
     mNames[(size_t)index]  = XMLTriple(name, namespaceURI, prefix);
   }
-  return LIBSBXML_OPERATION_SUCCESS;
+  return LIBLX_OPERATION_SUCCESS;
 }
 
 
@@ -183,7 +183,7 @@ XMLAttributes::addResource (const std::string& name, const std::string& value)
 {
   mNames .push_back( XMLTriple(name, "", "") );
   mValues.push_back( value );
-  return LIBSBXML_OPERATION_SUCCESS;
+  return LIBLX_OPERATION_SUCCESS;
 }
 /** @endcond */
 
@@ -198,7 +198,7 @@ XMLAttributes::removeResource (int n)
 {
   if (n < 0 || n >= getLength()) 
   {
-    return LIBSBXML_INDEX_EXCEEDS_SIZE;
+    return LIBLX_INDEX_EXCEEDS_SIZE;
   }
 
   vector<XMLTriple>::iterator   names_iter  = mNames.begin()  + n;
@@ -207,7 +207,7 @@ XMLAttributes::removeResource (int n)
   mNames.erase(names_iter);
   mValues.erase(values_iter);
 
-  return LIBSBXML_OPERATION_SUCCESS;
+  return LIBLX_OPERATION_SUCCESS;
 }
 /** @endcond */
 
@@ -252,7 +252,7 @@ XMLAttributes::clear()
 {
   mNames.clear();
   mValues.clear();
-  return LIBSBXML_OPERATION_SUCCESS;
+  return LIBLX_OPERATION_SUCCESS;
 }
 
 
@@ -1234,18 +1234,18 @@ XMLAttributes::setErrorLog (XMLErrorLog* log)
 {
   if (mLog == log)
   {
-    return LIBSBXML_OPERATION_SUCCESS;
+    return LIBLX_OPERATION_SUCCESS;
   }
   else if (log == NULL)
   {
     delete mLog;
     mLog = NULL;
-    return LIBSBXML_OPERATION_SUCCESS;
+    return LIBLX_OPERATION_SUCCESS;
   }
   else
   {
     mLog = log;
-    return LIBSBXML_OPERATION_SUCCESS;
+    return LIBLX_OPERATION_SUCCESS;
   }
 }
 /** @endcond */
@@ -1299,7 +1299,7 @@ XMLAttributes_add (XMLAttributes_t *xa,
                    const char *name,
                    const char *value)
 {
-  if (xa == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (xa == NULL) return LIBLX_INVALID_OBJECT;
   return xa->add(name, value);
 }
 
@@ -1312,7 +1312,7 @@ XMLAttributes_addWithNamespace (XMLAttributes_t *xa,
                                 const char* uri,
                                 const char* prefix)
 {
-  if (xa == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (xa == NULL) return LIBLX_INVALID_OBJECT;
   return xa->add(name, value, uri, prefix);
 }
 
@@ -1323,7 +1323,7 @@ XMLAttributes_addWithTriple ( XMLAttributes_t *xa
 			              , const XMLTriple_t* triple
 			              , const char *value)
 {
-  if (xa == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (xa == NULL) return LIBLX_INVALID_OBJECT;
   return xa->add(*triple, value);
 }
 
@@ -1332,7 +1332,7 @@ LIBLX_EXTERN
 int
 XMLAttributes_removeResource (XMLAttributes_t *xa, int n)
 {
-  if (xa == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (xa == NULL) return LIBLX_INVALID_OBJECT;
   return xa->removeResource(n);
 }
 
@@ -1341,7 +1341,7 @@ LIBLX_EXTERN
 int
 XMLAttributes_remove (XMLAttributes_t *xa, int n)
 {
-  if (xa == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (xa == NULL) return LIBLX_INVALID_OBJECT;
   return xa->remove(n);
 }
 
@@ -1350,7 +1350,7 @@ LIBLX_EXTERN
 int
 XMLAttributes_removeByName (XMLAttributes_t *xa, const char* name)
 {
-  if (xa == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (xa == NULL) return LIBLX_INVALID_OBJECT;
   return xa->remove(name);
 }
 
@@ -1359,7 +1359,7 @@ LIBLX_EXTERN
 int
 XMLAttributes_removeByNS (XMLAttributes_t *xa, const char* name, const char* uri)
 {
-  if (xa == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (xa == NULL) return LIBLX_INVALID_OBJECT;
   return xa->remove(name, uri);
 }
 
@@ -1368,7 +1368,7 @@ LIBLX_EXTERN
 int
 XMLAttributes_removeByTriple (XMLAttributes_t *xa, const XMLTriple_t* triple)
 {
-  if (xa == NULL || triple == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (xa == NULL || triple == NULL) return LIBLX_INVALID_OBJECT;
   return xa->remove(*triple);
 }
 
@@ -1377,7 +1377,7 @@ LIBLX_EXTERN
 int 
 XMLAttributes_clear(XMLAttributes_t *xa)
 {
-  if (xa == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (xa == NULL) return LIBLX_INVALID_OBJECT;
   return xa->clear();
 }
 

--- a/src/liblx/xml/XMLError.cpp
+++ b/src/liblx/xml/XMLError.cpp
@@ -706,7 +706,7 @@ int
 XMLError::setLine (unsigned int line)
 {
   mLine = line;
-  return LIBSBXML_OPERATION_SUCCESS;
+  return LIBLX_OPERATION_SUCCESS;
 }
 
 
@@ -717,7 +717,7 @@ int
 XMLError::setColumn (unsigned int column)
 {
   mColumn = column;
-  return LIBSBXML_OPERATION_SUCCESS;
+  return LIBLX_OPERATION_SUCCESS;
 }
 
 

--- a/src/liblx/xml/XMLError.h
+++ b/src/liblx/xml/XMLError.h
@@ -1023,7 +1023,7 @@ public:
    * @param line an unsigned int, the line number to set.
    *
    * @copydetails doc_returns_one_success_code
-   * @li @sbmlconstant{LIBSBXML_OPERATION_SUCCESS, OperationReturnValues_t}
+   * @li @sbmlconstant{LIBLX_OPERATION_SUCCESS, OperationReturnValues_t}
    *
    * @see setColumn(unsigned int column)
    */
@@ -1036,7 +1036,7 @@ public:
    * @param column an unsigned int, the column number to set.
    *
    * @copydetails doc_returns_one_success_code
-   * @li @sbmlconstant{LIBSBXML_OPERATION_SUCCESS, OperationReturnValues_t}
+   * @li @sbmlconstant{LIBLX_OPERATION_SUCCESS, OperationReturnValues_t}
    *
    * @see setLine(unsigned int line)
    */

--- a/src/liblx/xml/XMLErrorLog.cpp
+++ b/src/liblx/xml/XMLErrorLog.cpp
@@ -299,9 +299,9 @@ XMLErrorLog::setParser (const XMLParser* p)
   mParser = p;
 
   if (mParser != NULL)
-    return LIBSBXML_OPERATION_SUCCESS;
+    return LIBLX_OPERATION_SUCCESS;
   else
-    return LIBSBXML_OPERATION_FAILED;
+    return LIBLX_OPERATION_FAILED;
 }
 /** @endcond */
 

--- a/src/liblx/xml/XMLErrorLog.h
+++ b/src/liblx/xml/XMLErrorLog.h
@@ -220,8 +220,8 @@ public:
    * @param p XMLParser, the parser to use.
    *
    * @copydetails doc_returns_success_code
-   * @li @sbmlconstant{LIBSBXML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sbmlconstant{LIBSBXML_OPERATION_FAILED, OperationReturnValues_t}
+   * @li @sbmlconstant{LIBLX_OPERATION_SUCCESS, OperationReturnValues_t}
+   * @li @sbmlconstant{LIBLX_OPERATION_FAILED, OperationReturnValues_t}
    */
   int setParser (const XMLParser* p);
   /** @endcond */

--- a/src/liblx/xml/XMLInputStream.cpp
+++ b/src/liblx/xml/XMLInputStream.cpp
@@ -483,7 +483,7 @@ LIBLX_EXTERN
 int
 XMLInputStream_setErrorLog (XMLInputStream_t *stream, XMLErrorLog_t *log)
 {
-  if (stream == NULL ) return LIBSBXML_OPERATION_FAILED;
+  if (stream == NULL ) return LIBLX_OPERATION_FAILED;
   return stream->setErrorLog(log);
 }
 

--- a/src/liblx/xml/XMLNamespaces.cpp
+++ b/src/liblx/xml/XMLNamespaces.cpp
@@ -122,14 +122,14 @@ XMLNamespaces::add (const std::string& uri, const std::string prefix)
   //
   if (getURI(prefix).empty() == false && isURIReserved(getURI(prefix)))
   {
-      return LIBSBXML_OPERATION_FAILED;
+      return LIBLX_OPERATION_FAILED;
   }
 
   if ( prefix.empty()    ) removeDefault();
   if ( hasPrefix(prefix) ) remove(prefix);
 
   mNamespaces.push_back( make_pair(prefix, uri) );
-  return LIBSBXML_OPERATION_SUCCESS;
+  return LIBLX_OPERATION_SUCCESS;
 }
 
 
@@ -140,13 +140,13 @@ int XMLNamespaces::remove (int index)
 {
   if (index < 0 || index >= getLength()) 
   {
-    return LIBSBXML_INDEX_EXCEEDS_SIZE;
+    return LIBLX_INDEX_EXCEEDS_SIZE;
   }
 
   vector<PrefixURIPair>::iterator it = mNamespaces.begin() + index;
   mNamespaces.erase(it);
 
-  return LIBSBXML_OPERATION_SUCCESS;
+  return LIBLX_OPERATION_SUCCESS;
 }
 
 
@@ -159,13 +159,13 @@ int XMLNamespaces::remove (const std::string& prefix)
   int index = getIndexByPrefix(prefix);
   if(index == -1) 
   {
-    return LIBSBXML_INDEX_EXCEEDS_SIZE;
+    return LIBLX_INDEX_EXCEEDS_SIZE;
   }
 
   vector<PrefixURIPair>::iterator it = mNamespaces.begin() + index;
   mNamespaces.erase(it);
 
-  return LIBSBXML_OPERATION_SUCCESS;
+  return LIBLX_OPERATION_SUCCESS;
 }
 
 
@@ -178,11 +178,11 @@ XMLNamespaces::clear ()
   mNamespaces.clear();
   if (mNamespaces.empty())
   {
-    return LIBSBXML_OPERATION_SUCCESS;
+    return LIBLX_OPERATION_SUCCESS;
   }
   else
   {
-    return LIBSBXML_OPERATION_FAILED;
+    return LIBLX_OPERATION_FAILED;
   }
 }
 
@@ -484,7 +484,7 @@ int
 XMLNamespaces_add (XMLNamespaces_t *ns, 
 		   const char *uri, const char *prefix)
 {
-  if (ns == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (ns == NULL) return LIBLX_INVALID_OBJECT;
   return ns->add(uri, prefix);
 }
 
@@ -492,7 +492,7 @@ XMLNamespaces_add (XMLNamespaces_t *ns,
 LIBLX_EXTERN
 int XMLNamespaces_remove (XMLNamespaces_t *ns, int index)
 {
-  if (ns == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (ns == NULL) return LIBLX_INVALID_OBJECT;
   return ns->remove(index);
 }
 
@@ -500,7 +500,7 @@ int XMLNamespaces_remove (XMLNamespaces_t *ns, int index)
 LIBLX_EXTERN
 int XMLNamespaces_removeByPrefix (XMLNamespaces_t *ns, const char* prefix)
 {
-  if (ns == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (ns == NULL) return LIBLX_INVALID_OBJECT;
   return ns->remove(prefix);
 }
 
@@ -510,7 +510,7 @@ LIBLX_EXTERN
 int
 XMLNamespaces_clear (XMLNamespaces_t *ns)
 {
-  if (ns == NULL) return LIBSBXML_OPERATION_FAILED;
+  if (ns == NULL) return LIBLX_OPERATION_FAILED;
   return ns->clear();
 }
 

--- a/src/liblx/xml/XMLNode.cpp
+++ b/src/liblx/xml/XMLNode.cpp
@@ -245,18 +245,18 @@ XMLNode::addChild (const XMLNode& node)
     * an end element
     */
     if (isEnd()) unsetEnd();
-    return LIBSBXML_OPERATION_SUCCESS;
+    return LIBLX_OPERATION_SUCCESS;
   }
   else if (isEOF())
   {
     mChildren.push_back(new XMLNode(node));
     // this causes strange things to happen when node is written out
     //   this->mIsStart = true;
-    return LIBSBXML_OPERATION_SUCCESS;
+    return LIBLX_OPERATION_SUCCESS;
   }
   else
   {
-    return LIBSBXML_INVALID_XML_OPERATION;
+    return LIBLX_INVALID_XML_OPERATION;
   }
 
 }
@@ -313,7 +313,7 @@ XMLNode::removeChildren()
       ++curIt;
       }
   mChildren.clear(); 
-  return LIBSBXML_OPERATION_SUCCESS;
+  return LIBLX_OPERATION_SUCCESS;
 }
 
 
@@ -778,7 +778,7 @@ LIBLX_EXTERN
 int
 XMLNode_addChild (XMLNode_t *node, const XMLNode_t *child)
 {
-  if (node == NULL || child == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL || child == NULL) return LIBLX_INVALID_OBJECT;
   return node->addChild(*child);
 }
 
@@ -809,7 +809,7 @@ LIBLX_EXTERN
 int
 XMLNode_removeChildren (XMLNode_t *node)
 {
-  if (node == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL) return LIBLX_INVALID_OBJECT;
   return node->removeChildren();
 }
 
@@ -827,7 +827,7 @@ LIBLX_EXTERN
 int 
 XMLNode_setTriple(XMLNode_t *node, const XMLTriple_t *triple)
 {
-  if(node == NULL || triple == NULL) return LIBSBXML_INVALID_OBJECT;
+  if(node == NULL || triple == NULL) return LIBLX_INVALID_OBJECT;
   return node->setTriple(*triple);
 }
 
@@ -939,7 +939,7 @@ LIBLX_EXTERN
 int 
 XMLNode_setAttributes(XMLNode_t *node, const XMLAttributes_t* attributes)
 {
-  if (node == NULL || attributes == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL || attributes == NULL) return LIBLX_INVALID_OBJECT;
   return node->setAttributes(*attributes);
 }
 
@@ -948,7 +948,7 @@ LIBLX_EXTERN
 int 
 XMLNode_addAttr ( XMLNode_t *node,  const char* name, const char* value )
 {
-  if (node == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL) return LIBLX_INVALID_OBJECT;
   return node->addAttr(name, value, "", "");
 }
 
@@ -960,7 +960,7 @@ XMLNode_addAttrWithNS ( XMLNode_t *node,  const char* name
                         , const char* namespaceURI
                         , const char* prefix      )
 {
-  if (node == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL) return LIBLX_INVALID_OBJECT;
   return node->addAttr(name, value, namespaceURI, prefix);
 }
 
@@ -970,7 +970,7 @@ LIBLX_EXTERN
 int 
 XMLNode_addAttrWithTriple (XMLNode_t *node, const XMLTriple_t *triple, const char* value)
 {
-  if (node == NULL || triple == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL || triple == NULL) return LIBLX_INVALID_OBJECT;
   return node->addAttr(*triple, value);
 }
 
@@ -979,7 +979,7 @@ LIBLX_EXTERN
 int 
 XMLNode_removeAttr (XMLNode_t *node, int n)
 {
-  if (node == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL) return LIBLX_INVALID_OBJECT;
   return node->removeAttr(n);
 }
 
@@ -988,7 +988,7 @@ LIBLX_EXTERN
 int 
 XMLNode_removeAttrByName (XMLNode_t *node, const char* name)
 {
-  if (node == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL) return LIBLX_INVALID_OBJECT;
   return node->removeAttr(name, "");
 }
 
@@ -997,7 +997,7 @@ LIBLX_EXTERN
 int 
 XMLNode_removeAttrByNS (XMLNode_t *node, const char* name, const char* uri)
 {
-  if (node == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL) return LIBLX_INVALID_OBJECT;
   return node->removeAttr(name, uri);
 }
 
@@ -1006,7 +1006,7 @@ LIBLX_EXTERN
 int 
 XMLNode_removeAttrByTriple (XMLNode_t *node, const XMLTriple_t *triple)
 {
-  if (node == NULL || triple == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL || triple == NULL) return LIBLX_INVALID_OBJECT;
   return node->removeAttr(*triple);
 }
 
@@ -1015,7 +1015,7 @@ LIBLX_EXTERN
 int 
 XMLNode_clearAttributes(XMLNode_t *node)
 {
-  if (node == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL) return LIBLX_INVALID_OBJECT;
   return node->clearAttributes();
 }
 
@@ -1201,7 +1201,7 @@ LIBLX_EXTERN
 int 
 XMLNode_setNamespaces(XMLNode_t *node, const XMLNamespaces_t* namespaces)
 {
-  if (node == NULL || namespaces == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL || namespaces == NULL) return LIBLX_INVALID_OBJECT;
   return node->setNamespaces(*namespaces);
 }
 
@@ -1210,7 +1210,7 @@ LIBLX_EXTERN
 int 
 XMLNode_addNamespace (XMLNode_t *node, const char* uri, const char* prefix)
 {
-  if (node == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL) return LIBLX_INVALID_OBJECT;
   return node->addNamespace(uri, prefix);
 }
 
@@ -1219,7 +1219,7 @@ LIBLX_EXTERN
 int 
 XMLNode_removeNamespace (XMLNode_t *node, int index)
 {
-  if (node == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL) return LIBLX_INVALID_OBJECT;
   return node->removeNamespace(index);
 }
 
@@ -1228,7 +1228,7 @@ LIBLX_EXTERN
 int 
 XMLNode_removeNamespaceByPrefix (XMLNode_t *node, const char* prefix)
 {
-  if (node == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL) return LIBLX_INVALID_OBJECT;
   return node->removeNamespace(prefix);
 }
 
@@ -1237,7 +1237,7 @@ LIBLX_EXTERN
 int 
 XMLNode_clearNamespaces (XMLNode_t *node)
 {
-  if (node == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL) return LIBLX_INVALID_OBJECT;
   return node->clearNamespaces();
 }
 
@@ -1435,7 +1435,7 @@ LIBLX_EXTERN
 int
 XMLNode_setEnd (XMLNode_t *node)
 {
-  if (node == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL) return LIBLX_INVALID_OBJECT;
   return node->setEnd();
 }
 
@@ -1444,7 +1444,7 @@ LIBLX_EXTERN
 int
 XMLNode_setEOF (XMLNode_t *node)
 {
-  if (node == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL) return LIBLX_INVALID_OBJECT;
   return node->setEOF();
 }
 
@@ -1453,7 +1453,7 @@ LIBLX_EXTERN
 int
 XMLNode_unsetEnd (XMLNode_t *node)
 {
-  if (node == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (node == NULL) return LIBLX_INVALID_OBJECT;
   return node->unsetEnd();
 }
 /** @endcond */

--- a/src/liblx/xml/XMLParser.cpp
+++ b/src/liblx/xml/XMLParser.cpp
@@ -132,7 +132,7 @@ XMLParser::setErrorLog (XMLErrorLog* log)
   }
   else
   {
-    return LIBSBXML_OPERATION_FAILED;
+    return LIBLX_OPERATION_FAILED;
   }
 }
 

--- a/src/liblx/xml/XMLToken.cpp
+++ b/src/liblx/xml/XMLToken.cpp
@@ -228,12 +228,12 @@ XMLToken::append (const std::string& chars)
 {
   if (chars.empty())
   {
-    return LIBSBXML_OPERATION_FAILED;
+    return LIBLX_OPERATION_FAILED;
   }
   else
   {
     mChars.append(chars);
-    return LIBSBXML_OPERATION_SUCCESS;
+    return LIBLX_OPERATION_SUCCESS;
   }
 }
 
@@ -254,12 +254,12 @@ XMLToken::setCharacters(const std::string& chars)
 {
   if (chars.empty())
   {
-    return LIBSBXML_OPERATION_FAILED;
+    return LIBLX_OPERATION_FAILED;
   }
   else
   {
     mChars = chars;
-    return LIBSBXML_OPERATION_SUCCESS;
+    return LIBLX_OPERATION_SUCCESS;
   }
 }
 
@@ -313,16 +313,16 @@ XMLToken::setAttributes(const XMLAttributes& attributes)
     try
     {
       mAttributes = attributes;
-      return LIBSBXML_OPERATION_SUCCESS;
+      return LIBLX_OPERATION_SUCCESS;
     }
     catch (...)
     {
-      return LIBSBXML_OPERATION_FAILED;
+      return LIBLX_OPERATION_FAILED;
     }
   }
   else
   {
-    return LIBSBXML_INVALID_XML_OPERATION;
+    return LIBLX_INVALID_XML_OPERATION;
   }
 }
 
@@ -364,7 +364,7 @@ XMLToken::addAttr (  const std::string& name
   }
   else
   {
-    return LIBSBXML_INVALID_XML_OPERATION;
+    return LIBLX_INVALID_XML_OPERATION;
   }
 }
 
@@ -389,7 +389,7 @@ XMLToken::addAttr ( const XMLTriple& triple, const std::string& value)
   }
   else
   {
-    return LIBSBXML_INVALID_XML_OPERATION;
+    return LIBLX_INVALID_XML_OPERATION;
   }
 }
 
@@ -410,7 +410,7 @@ XMLToken::removeAttr (int n)
   }
   else
   {
-    return LIBSBXML_INVALID_XML_OPERATION;
+    return LIBLX_INVALID_XML_OPERATION;
   }
 }
 
@@ -432,7 +432,7 @@ XMLToken::removeAttr (const std::string& name, const std::string uri)
   }
   else
   {
-    return LIBSBXML_INVALID_XML_OPERATION;
+    return LIBLX_INVALID_XML_OPERATION;
   }
 }
 
@@ -453,7 +453,7 @@ XMLToken::removeAttr (const XMLTriple& triple)
   }
   else
   {
-    return LIBSBXML_INVALID_XML_OPERATION;
+    return LIBLX_INVALID_XML_OPERATION;
   }
 }
 
@@ -471,7 +471,7 @@ XMLToken::clearAttributes()
   }
   else
   {
-    return LIBSBXML_INVALID_XML_OPERATION;
+    return LIBLX_INVALID_XML_OPERATION;
   }
 }
 
@@ -780,16 +780,16 @@ XMLToken::setNamespaces(const XMLNamespaces& namespaces)
     try
     {
       mNamespaces = namespaces;
-      return LIBSBXML_OPERATION_SUCCESS;
+      return LIBLX_OPERATION_SUCCESS;
     }
     catch (...)
     {
-      return LIBSBXML_OPERATION_FAILED;
+      return LIBLX_OPERATION_FAILED;
     }
   }
   else
   {
-    return LIBSBXML_INVALID_XML_OPERATION;
+    return LIBLX_INVALID_XML_OPERATION;
   }
 }
 
@@ -808,11 +808,11 @@ XMLToken::addNamespace (const std::string& uri, const std::string prefix)
    if (mIsStart)  
    {
      mNamespaces.add(uri, prefix);
-     return LIBSBXML_OPERATION_SUCCESS;
+     return LIBLX_OPERATION_SUCCESS;
    }
   else
   {
-    return LIBSBXML_INVALID_XML_OPERATION;
+    return LIBLX_INVALID_XML_OPERATION;
   }
 }
 
@@ -833,7 +833,7 @@ XMLToken::removeNamespace (int index)
    }
   else
   {
-    return LIBSBXML_INVALID_XML_OPERATION;
+    return LIBLX_INVALID_XML_OPERATION;
   }
 }
 
@@ -853,7 +853,7 @@ XMLToken::removeNamespace (const std::string& prefix)
   }
   else
   {
-    return LIBSBXML_INVALID_XML_OPERATION;
+    return LIBLX_INVALID_XML_OPERATION;
   }
 }
 
@@ -872,7 +872,7 @@ XMLToken::clearNamespaces ()
   }
   else
   {
-    return LIBSBXML_INVALID_XML_OPERATION;
+    return LIBLX_INVALID_XML_OPERATION;
   }
 }
 
@@ -1051,16 +1051,16 @@ XMLToken::setTriple(const XMLTriple& triple)
     try
     {
       mTriple = triple;
-      return LIBSBXML_OPERATION_SUCCESS;
+      return LIBLX_OPERATION_SUCCESS;
     }
     catch (...)
     {
-      return LIBSBXML_OPERATION_FAILED;
+      return LIBLX_OPERATION_FAILED;
     }
   }
   else
   {
-    return LIBSBXML_INVALID_XML_OPERATION;
+    return LIBLX_INVALID_XML_OPERATION;
   }
 
 }
@@ -1175,9 +1175,9 @@ XMLToken::setEnd ()
 {
   mIsEnd = true;
   if (isEnd())
-    return LIBSBXML_OPERATION_SUCCESS;
+    return LIBLX_OPERATION_SUCCESS;
   else
-    return LIBSBXML_OPERATION_FAILED;
+    return LIBLX_OPERATION_FAILED;
 }
 
 
@@ -1189,9 +1189,9 @@ XMLToken::unsetEnd ()
 {
   mIsEnd = false;
   if (!isEnd())
-    return LIBSBXML_OPERATION_SUCCESS;
+    return LIBLX_OPERATION_SUCCESS;
   else
-    return LIBSBXML_OPERATION_FAILED;
+    return LIBLX_OPERATION_FAILED;
 }
 
 
@@ -1206,9 +1206,9 @@ XMLToken::setEOF ()
   mIsText  = false;
 
   if (isEOF())
-    return LIBSBXML_OPERATION_SUCCESS;
+    return LIBLX_OPERATION_SUCCESS;
   else
-    return LIBSBXML_OPERATION_FAILED;
+    return LIBLX_OPERATION_FAILED;
 }
 
 
@@ -1351,7 +1351,7 @@ XMLToken_append (XMLToken_t *token, const char *text)
   }
   else
   {
-    return LIBSBXML_OPERATION_FAILED;
+    return LIBLX_OPERATION_FAILED;
   }
 }
 
@@ -1365,7 +1365,7 @@ XMLToken_setCharacters(XMLToken_t *token, const char *text)
   }
   else
   {
-    return LIBSBXML_OPERATION_FAILED;
+    return LIBLX_OPERATION_FAILED;
   }
 }
 
@@ -1412,7 +1412,7 @@ LIBLX_EXTERN
 int 
 XMLToken_setAttributes(XMLToken_t *token, const XMLAttributes_t* attributes)
 {
-  if (token == NULL || attributes == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL || attributes == NULL) return LIBLX_INVALID_OBJECT;
   return token->setAttributes(*attributes);
 }
 
@@ -1421,7 +1421,7 @@ LIBLX_EXTERN
 int 
 XMLToken_addAttr ( XMLToken_t *token,  const char* name, const char* value )
 {
-  if (token == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL) return LIBLX_INVALID_OBJECT;
   return token->addAttr(name, value, "", "");
 }
 
@@ -1433,7 +1433,7 @@ XMLToken_addAttrWithNS ( XMLToken_t *token,  const char* name
                       , const char* namespaceURI
                   , const char* prefix      )
 {
-  if (token == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL) return LIBLX_INVALID_OBJECT;
   return token->addAttr(name, value, namespaceURI, prefix);
 }
 
@@ -1443,7 +1443,7 @@ LIBLX_EXTERN
 int 
 XMLToken_addAttrWithTriple (XMLToken_t *token, const XMLTriple_t *triple, const char* value)
 {
-  if (token == NULL || triple == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL || triple == NULL) return LIBLX_INVALID_OBJECT;
   return token->addAttr(*triple, value);
 }
 
@@ -1452,7 +1452,7 @@ LIBLX_EXTERN
 int 
 XMLToken_removeAttr (XMLToken_t *token, int n)
 {
-  if (token == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL) return LIBLX_INVALID_OBJECT;
   return token->removeAttr(n);
 }
 
@@ -1461,7 +1461,7 @@ LIBLX_EXTERN
 int 
 XMLToken_removeAttrByName (XMLToken_t *token, const char* name)
 {
-  if (token == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL) return LIBLX_INVALID_OBJECT;
   return token->removeAttr(name, "");
 }
 
@@ -1470,7 +1470,7 @@ LIBLX_EXTERN
 int 
 XMLToken_removeAttrByNS (XMLToken_t *token, const char* name, const char* uri)
 {
-  if (token == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL) return LIBLX_INVALID_OBJECT;
   return token->removeAttr(name, uri);
 }
 
@@ -1479,7 +1479,7 @@ LIBLX_EXTERN
 int 
 XMLToken_removeAttrByTriple (XMLToken_t *token, const XMLTriple_t *triple)
 {
-  if (token == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL) return LIBLX_INVALID_OBJECT;
   return token->removeAttr(*triple);
 }
 
@@ -1488,7 +1488,7 @@ LIBLX_EXTERN
 int 
 XMLToken_clearAttributes(XMLToken_t *token)
 {
-  if (token == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL) return LIBLX_INVALID_OBJECT;
   return token->clearAttributes();
 }
 
@@ -1668,7 +1668,7 @@ LIBLX_EXTERN
 int 
 XMLToken_setNamespaces(XMLToken_t *token, const XMLNamespaces_t* namespaces)
 {
-  if (token == NULL || namespaces == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL || namespaces == NULL) return LIBLX_INVALID_OBJECT;
   return token->setNamespaces(*namespaces);
 }
 
@@ -1677,7 +1677,7 @@ LIBLX_EXTERN
 int 
 XMLToken_addNamespace (XMLToken_t *token, const char* uri, const char* prefix)
 {
-  if (token == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL) return LIBLX_INVALID_OBJECT;
   return token->addNamespace(uri, prefix);
 }
 
@@ -1686,7 +1686,7 @@ LIBLX_EXTERN
 int 
 XMLToken_removeNamespace (XMLToken_t *token, int index)
 {
-  if (token == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL) return LIBLX_INVALID_OBJECT;
   return token->removeNamespace(index);
 }
 
@@ -1695,7 +1695,7 @@ LIBLX_EXTERN
 int 
 XMLToken_removeNamespaceByPrefix (XMLToken_t *token, const char* prefix)
 {
-  if (token == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL) return LIBLX_INVALID_OBJECT;
   return token->removeNamespace(prefix);
 }
 
@@ -1704,7 +1704,7 @@ LIBLX_EXTERN
 int 
 XMLToken_clearNamespaces (XMLToken_t *token)
 {
-  if (token == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL) return LIBLX_INVALID_OBJECT;
   return token->clearNamespaces();
 }
 
@@ -1820,7 +1820,7 @@ LIBLX_EXTERN
 int 
 XMLToken_setTriple(XMLToken_t *token, const XMLTriple_t *triple)
 {
-  if (token == NULL || triple == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL || triple == NULL) return LIBLX_INVALID_OBJECT;
   return token->setTriple(*triple);
 }
 
@@ -1910,7 +1910,7 @@ LIBLX_EXTERN
 int
 XMLToken_setEnd (XMLToken_t *token)
 {
-  if (token == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL) return LIBLX_INVALID_OBJECT;
   return token->setEnd();
 }
 
@@ -1919,7 +1919,7 @@ LIBLX_EXTERN
 int
 XMLToken_setEOF (XMLToken_t *token)
 {
-  if (token == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL) return LIBLX_INVALID_OBJECT;
   return token->setEOF();
 }
 
@@ -1928,7 +1928,7 @@ LIBLX_EXTERN
 int
 XMLToken_unsetEnd (XMLToken_t *token)
 {
-  if (token == NULL) return LIBSBXML_INVALID_OBJECT;
+  if (token == NULL) return LIBLX_INVALID_OBJECT;
   return token->unsetEnd();
 }
 /** @endcond */

--- a/src/liblx/xml/operationReturnValues.h
+++ b/src/liblx/xml/operationReturnValues.h
@@ -34,23 +34,23 @@
  * also available online as http://sbml.org/software/libsbml/license.html
  * ---------------------------------------------------------------------- -->*/
 
-#ifndef LIBSBXML_OPERATION_RETURN_VALUES_H
-#define LIBSBXML_OPERATION_RETURN_VALUES_H
+#ifndef LIBLX_OPERATION_RETURN_VALUES_H
+#define LIBLX_OPERATION_RETURN_VALUES_H
 
 /**
  * @enum OperationReturnValues_t
- * LibSBML diagnostic return codes.
+ * LibLX diagnostic return codes.
  *
- * Many methods in libSBML return a status code to indicate whether the
+ * Many methods in libLX return a status code to indicate whether the
  * operation requested by the caller succeeded or failed.  This enumeration
- * lists all the possible return codes from any libSBML methods.
+ * lists all the possible return codes from any libLX methods.
  */
 typedef enum
 {
-    LIBSBXML_OPERATION_SUCCESS       = 0
+    LIBLX_OPERATION_SUCCESS       = 0
     /*!< The operation was successful. */
 
-  , LIBSBXML_INDEX_EXCEEDS_SIZE      = -1
+  , LIBLX_INDEX_EXCEEDS_SIZE      = -1
     /*!< An index parameter exceeded the bounds of a data array or other
      * collection used in the operation.  This return value is typically
      * returned by methods that take index numbers to refer to lists
@@ -59,7 +59,7 @@ typedef enum
      * size of list/sequence/collection structures, and callers should
      * verify the sizes before calling methods that take index numbers. */
 
-  , LIBSBXML_UNEXPECTED_ATTRIBUTE    = -2
+  , LIBLX_UNEXPECTED_ATTRIBUTE    = -2
     /*!< The attribute that is the subject of this operation is not valid
      * for the combination of SBML Level and Version for the underlying
      * object.  This can happen because libSBML strives to offer a uniform
@@ -69,40 +69,40 @@ typedef enum
      * are working with, but when errors of this kind occur, they are
      * reported using this return value. */
 
-  , LIBSBXML_OPERATION_FAILED        = -3
+  , LIBLX_OPERATION_FAILED        = -3
     /*!< The requested action could not be performed.  This can occur in
      * a variety of contexts, such as passing a null object as a parameter
      * in a situation where it does not make sense to permit a null object.
      */
 
-  , LIBSBXML_INVALID_ATTRIBUTE_VALUE = -4
+  , LIBLX_INVALID_ATTRIBUTE_VALUE = -4
     /*!< A value passed as an argument to the method is not of a type that
      * is valid for the operation or kind of object involved.  For example,
      * this return code is used when a calling program attempts to set an
      * SBML object identifier to a string whose syntax does not conform to
      * the SBML identifier syntax. */
 
-  , LIBSBXML_INVALID_OBJECT          = -5
+  , LIBLX_INVALID_OBJECT          = -5
     /*!< The object passed as an argument to the method is not of a type
      * that is valid for the operation or kind of object involved.  For
      * example, handing an invalidly-constructed ASTNode to a method
      * expecting an ASTNode will result in this error. */
 
-  , LIBSBXML_DUPLICATE_OBJECT_ID     = -6
+  , LIBLX_DUPLICATE_OBJECT_ID     = -6
     /*!< There already exists an object with this identifier in the
      * context where this operation is being attempted.  This error is
      * typically returned in situations where SBML object identifiers must be
      * unique, such as attempting to add two species with the same identifier
      * to a model. */
 
-  , LIBSBXML_LEVEL_MISMATCH          = -7
+  , LIBLX_LEVEL_MISMATCH          = -7
     /*!< The SBML Level associated with the object does not match the Level
      * of the parent object.  This error can happen when an SBML component
      * such as a species or compartment object is created outside of a model
      * and a calling program then attempts to add the object to a model that
      * has a different SBML Level defined. */
 
-  , LIBSBXML_VERSION_MISMATCH        = -8
+  , LIBLX_VERSION_MISMATCH        = -8
     /*!< The SBML Version within the SBML Level associated with the object
      * does not match the Version of the parent object.  This error can
      * happen when an SBML component such as a species or compartment object
@@ -110,13 +110,13 @@ typedef enum
      * add the object to a model that has a different SBML Level+Version
      * combination. */
 
-  , LIBSBXML_INVALID_XML_OPERATION   = -9
+  , LIBLX_INVALID_XML_OPERATION   = -9
     /*!< The XML operation attempted is not valid for the object or context
      * involved.  This error is typically returned by the XML interface layer
      * of libSBML, when a calling program attempts to construct or manipulate
      * XML in an invalid way.  */
 
-  , LIBSBXML_NAMESPACES_MISMATCH   = -10
+  , LIBLX_NAMESPACES_MISMATCH   = -10
     /*!< The SBML Namespaces associated with the object
      * do not match the SBML Namespaces of the parent object.  This error can
      * happen when an SBML component such as a species or compartment object
@@ -124,14 +124,14 @@ typedef enum
      * add the object to a model that has a different SBML Namespaces
      * combination. */
 
-  , LIBSBXML_DUPLICATE_ANNOTATION_NS   = -11
+  , LIBLX_DUPLICATE_ANNOTATION_NS   = -11
     /*!< There already exists a top level annotation with the same namespace as
      * annotation being appended.  This error is
      * typically returned in situations where the appendAnnotation function
      * is being used to add an annotation that has a namespace that is already
      * present in the existing annotation. */
 
-  , LIBSBXML_ANNOTATION_NAME_NOT_FOUND   = -12
+  , LIBLX_ANNOTATION_NAME_NOT_FOUND   = -12
     /*!< The existing annotation does not have a top-level element with
      * the given name. This error is
      * typically returned in situations where the
@@ -141,7 +141,7 @@ typedef enum
      * not match the name of any top-level element that is already
      * present in the existing annotation. */
 
-   , LIBSBXML_ANNOTATION_NS_NOT_FOUND   = -13
+   , LIBLX_ANNOTATION_NS_NOT_FOUND   = -13
     /*!< The existing annotation does not have a top-level element with
      * the given namespace. This error is
      * typically returned in situations where the
@@ -151,16 +151,16 @@ typedef enum
      * not match the namespace of any top-level element that is already
      * present in the existing annotation. */
 
-     , LIBSBXML_MISSING_METAID   = -14
+     , LIBLX_MISSING_METAID   = -14
     /*!< The requested action cannot be performed as the target object does not have
      * the metaid attribute set. */
 
-     , LIBSBXML_DEPRECATED_ATTRIBUTE   = -15
+     , LIBLX_DEPRECATED_ATTRIBUTE   = -15
     /*!< The attribute that is the subject of this operation has been deprecated
      * for the combination of SBML Level and Version for the underlying
      * object. */
 
-     , LIBSBXML_USE_ID_ATTRIBUTE_FUNCTION   = -16
+     , LIBLX_USE_ID_ATTRIBUTE_FUNCTION   = -16
     /*!< For L3V2 use the IdAttribute functions. */
 
    /* ---------------------------------------------------------------------------
@@ -169,7 +169,7 @@ typedef enum
     *
     * -------------------------------------------------------------------------- */
 
-  , LIBSBXML_PKG_VERSION_MISMATCH  = -20
+  , LIBLX_PKG_VERSION_MISMATCH  = -20
     /*!< The Version of package extension within the SBML Level and version
      * associated with the object does not match the Version of the parent
      * object. This error can happen when an SBML component such as a layout
@@ -177,7 +177,7 @@ typedef enum
      * then attempts to add the object to a model that has a different SBML
      * Level+Version+Package Version combination. */
 
-   , LIBSBXML_PKG_UNKNOWN           = -21
+   , LIBLX_PKG_UNKNOWN           = -21
     /*!< The required package extension is unknown. This error is typically
      * returned when creating an object of SBase derived class with the required
      * package, creating an object of SBMLNamespaces or its derived class with the
@@ -186,7 +186,7 @@ typedef enum
      * linked.
      */
 
-   , LIBSBXML_PKG_UNKNOWN_VERSION    = -22
+   , LIBLX_PKG_UNKNOWN_VERSION    = -22
     /*!< The required version of the package extension is unknown. This error
      * is typically returned when creating an object of SBase derived class with
      * the required package, creating an object of SBMLNamespaces or its derived
@@ -195,7 +195,7 @@ typedef enum
      * required package to be linked.
      */
 
-   , LIBSBXML_PKG_DISABLED            = -23
+   , LIBLX_PKG_DISABLED            = -23
     /*!< The required package extension is disabled. This error is typically
      * returned when creating an object of SBase derived class with the required
      * package, creating an object of SBMLNamespaces or its derived class with the
@@ -203,7 +203,7 @@ typedef enum
      * To avoid this error, the library of the required package needs to be enabled.
      */
 
-   , LIBSBXML_PKG_CONFLICTED_VERSION  = -24
+   , LIBLX_PKG_CONFLICTED_VERSION  = -24
     /*!< Another version of the required package extension has already been enabled
      * in the target SBase object, or enabled in the model to/in which the target
      * object to be added/contained. This error is typically returned  when adding an
@@ -212,7 +212,7 @@ typedef enum
      * To avoid this error, the conflict of versions need to be avoided.
      */
 
-   , LIBSBXML_PKG_CONFLICT            = -25
+   , LIBLX_PKG_CONFLICT            = -25
     /*!< Another SBML package extension for the same URI has already been registered.
      * This error is typically returned when adding a SBML package extension to the
      * SBMLExtensionRegistry. To avoid this error, ensure that SBML package
@@ -225,7 +225,7 @@ typedef enum
     *
     * -------------------------------------------------------------------------- */
 
-  , LIBSBXML_CONV_INVALID_TARGET_NAMESPACE  = -30
+  , LIBLX_CONV_INVALID_TARGET_NAMESPACE  = -30
     /*!< The target namespace is not a valid SBML namespace. while
      * attempting to convert the SBML document using
      * SBMLLevelVersionConverter::convert() or related methods, the target
@@ -234,7 +234,7 @@ typedef enum
      * detecting this situation and preventing the error.)
      */
 
-  , LIBSBXML_CONV_PKG_CONVERSION_NOT_AVAILABLE = -31
+  , LIBLX_CONV_PKG_CONVERSION_NOT_AVAILABLE = -31
     /*!< Conversions involving packages are not available in the specified
      * routine. This error is typically returned when calling a converter
      * that does not have the functionality to deal with SBML Level&nbsp;3
@@ -242,7 +242,7 @@ typedef enum
      * ConversionProperties specifies packages.
      */
 
-  , LIBSBXML_CONV_INVALID_SRC_DOCUMENT = -32
+  , LIBLX_CONV_INVALID_SRC_DOCUMENT = -32
     /*!< The document on which conversion is being requested is invalid and
      * the requested conversion cannot be performed. This error is
      * typically returned when a conversion routine has been given an
@@ -252,11 +252,11 @@ typedef enum
      * resolve errors before passing the document to a conversion method.
      */
 
-  , LIBSBXML_CONV_CONVERSION_NOT_AVAILABLE = -33
+  , LIBLX_CONV_CONVERSION_NOT_AVAILABLE = -33
     /*!< Conversion with the given properties is not yet available.
      */
 
-  , LIBSBXML_CONV_PKG_CONSIDERED_UNKNOWN = -34
+  , LIBLX_CONV_PKG_CONSIDERED_UNKNOWN = -34
     /*!< The package that is being stripped is not an enabled
      * package but considered by libSBML to be an unrecognized
      * package.  This error is typically returned when calling
@@ -270,5 +270,5 @@ typedef enum
 } OperationReturnValues_t;
 
 
-#endif  /*ndef LIBSBXML_OPERATION_RETURN_VALUES_H */
+#endif  /*ndef LIBLX_OPERATION_RETURN_VALUES_H */
 

--- a/src/liblx/xml/test/TestRunner.c
+++ b/src/liblx/xml/test/TestRunner.c
@@ -37,7 +37,7 @@
 #include <string.h>
 #include <check.h>
 
-#ifdef LIBSBXML_USE_VLD
+#ifdef LIBLX_USE_VLD
   #include <vld.h>
 #endif
 

--- a/src/liblx/xml/test/TestXMLAttributesC.c
+++ b/src/liblx/xml/test/TestXMLAttributesC.c
@@ -397,18 +397,18 @@ START_TEST(test_XMLAttributes_add1)
 
   int i = XMLAttributes_addWithNamespace(xa, "name1", "val1", "http://name1.org/", "p1");
   
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
 
   i = XMLAttributes_addWithTriple(xa, xt2, "val2");
   
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
 
   fail_unless( XMLAttributes_getLength(xa) == 2 );
   fail_unless( XMLAttributes_isEmpty(xa)   == 0 );
 
   i = XMLAttributes_add(xa, "noprefix", "val3");
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLAttributes_getLength(xa) == 3 );
   fail_unless( XMLAttributes_isEmpty(xa)   == 0 );
 
@@ -902,43 +902,43 @@ START_TEST(test_XMLAttributes_remove1)
 
   int i = XMLAttributes_addWithNamespace(xa, "name1", "val1", "http://name1.org/", "p1");
   
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
 
   i = XMLAttributes_addWithTriple(xa, xt2, "val2");
   
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
 
   i = XMLAttributes_add(xa, "noprefix", "val3");
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   
   i = XMLAttributes_addWithNamespace(xa, "name4", "val4", "http://name4.org/", "p1");
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLAttributes_getLength(xa) == 4 );
 
   i = XMLAttributes_remove(xa, 4);
 
-  fail_unless(i == LIBSBXML_INDEX_EXCEEDS_SIZE);
+  fail_unless(i == LIBLX_INDEX_EXCEEDS_SIZE);
 
   i = XMLAttributes_remove(xa, 3);
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLAttributes_getLength(xa) == 3 );
 
   i = XMLAttributes_removeByName(xa, "noprefix");
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLAttributes_getLength(xa) ==  2);
 
   i = XMLAttributes_removeByTriple(xa, xt2);
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLAttributes_getLength(xa) ==  1);
 
   i = XMLAttributes_removeByNS(xa, "name1", "http://name1.org/");
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLAttributes_getLength(xa) ==  0);
 
   XMLAttributes_free(xa);
@@ -959,7 +959,7 @@ START_TEST(test_XMLAttributes_clear1)
 
   i = XMLAttributes_clear(xa);
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLAttributes_getLength(xa) == 0 );
   fail_unless( XMLAttributes_isEmpty(xa)   == 1 );
 
@@ -970,12 +970,12 @@ END_TEST
 
 START_TEST(test_XMLAttributes_accessWithNULL)
 {
-  fail_unless ( XMLAttributes_add(NULL, NULL, NULL) == LIBSBXML_INVALID_OBJECT );  
+  fail_unless ( XMLAttributes_add(NULL, NULL, NULL) == LIBLX_INVALID_OBJECT );  
   fail_unless ( XMLAttributes_addWithNamespace(NULL, NULL, NULL, NULL, NULL) 
-      == LIBSBXML_INVALID_OBJECT );
+      == LIBLX_INVALID_OBJECT );
   fail_unless ( XMLAttributes_addWithTriple(NULL, NULL, NULL) 
-      == LIBSBXML_INVALID_OBJECT );
-  fail_unless ( XMLAttributes_clear(NULL) == LIBSBXML_INVALID_OBJECT );  
+      == LIBLX_INVALID_OBJECT );
+  fail_unless ( XMLAttributes_clear(NULL) == LIBLX_INVALID_OBJECT );  
   fail_unless ( XMLAttributes_clone(NULL) == NULL );  
 
   XMLAttributes_free(NULL);
@@ -1008,11 +1008,11 @@ START_TEST(test_XMLAttributes_accessWithNULL)
   fail_unless ( XMLAttributes_readIntoStringByTriple(NULL, NULL, NULL, NULL, 0) == 0 );  
   fail_unless ( XMLAttributes_readIntoUnsignedInt(NULL, NULL, NULL, NULL, 0) == 0 );  
   fail_unless ( XMLAttributes_readIntoUnsignedIntByTriple(NULL, NULL, NULL, NULL, 0) == 0 );  
-  fail_unless ( XMLAttributes_remove(NULL, 0) == LIBSBXML_INVALID_OBJECT );  
-  fail_unless ( XMLAttributes_removeByName(NULL, NULL) == LIBSBXML_INVALID_OBJECT );  
-  fail_unless ( XMLAttributes_removeByNS(NULL, NULL, NULL) == LIBSBXML_INVALID_OBJECT );  
-  fail_unless ( XMLAttributes_removeByTriple(NULL, NULL) == LIBSBXML_INVALID_OBJECT );  
-  fail_unless ( XMLAttributes_removeResource(NULL, 0) == LIBSBXML_INVALID_OBJECT );  
+  fail_unless ( XMLAttributes_remove(NULL, 0) == LIBLX_INVALID_OBJECT );  
+  fail_unless ( XMLAttributes_removeByName(NULL, NULL) == LIBLX_INVALID_OBJECT );  
+  fail_unless ( XMLAttributes_removeByNS(NULL, NULL, NULL) == LIBLX_INVALID_OBJECT );  
+  fail_unless ( XMLAttributes_removeByTriple(NULL, NULL) == LIBLX_INVALID_OBJECT );  
+  fail_unless ( XMLAttributes_removeResource(NULL, 0) == LIBLX_INVALID_OBJECT );  
 }
 END_TEST
 

--- a/src/liblx/xml/test/TestXMLError.cpp
+++ b/src/liblx/xml/test/TestXMLError.cpp
@@ -118,12 +118,12 @@ START_TEST (test_XMLError_setters)
 
   int i = error->setLine(23);
 
-  fail_unless(i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless(i == LIBLX_OPERATION_SUCCESS);
   fail_unless( error->getLine() == 23);
 
   i = error->setColumn(45);
 
-  fail_unless(i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless(i == LIBLX_OPERATION_SUCCESS);
   fail_unless( error->getColumn() == 45);
 
   delete error;

--- a/src/liblx/xml/test/TestXMLInputStream.c
+++ b/src/liblx/xml/test/TestXMLInputStream.c
@@ -183,11 +183,11 @@ START_TEST (test_XMLInputStream_setErrorLog)
 
   int i = XMLInputStream_setErrorLog(stream, log);
 
-  fail_unless(i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless(i == LIBLX_OPERATION_SUCCESS);
   fail_unless(XMLInputStream_getErrorLog(stream) == log);
   
   i = XMLInputStream_setErrorLog(stream, NULL);
-  fail_unless(i == LIBSBXML_OPERATION_FAILED);
+  fail_unless(i == LIBLX_OPERATION_FAILED);
 
 
   XMLErrorLog_free(log);
@@ -208,7 +208,7 @@ START_TEST (test_XMLInputStream_accessWithNULL)
   fail_unless (XMLInputStream_isGood(NULL) == 0);
   fail_unless (XMLInputStream_next(NULL) == NULL);
   fail_unless (XMLInputStream_peek(NULL) == NULL);
-  fail_unless (XMLInputStream_setErrorLog(NULL, NULL) == LIBSBXML_OPERATION_FAILED);
+  fail_unless (XMLInputStream_setErrorLog(NULL, NULL) == LIBLX_OPERATION_FAILED);
 
   XMLInputStream_skipPastEnd(NULL, NULL);
   XMLInputStream_skipText(NULL);  

--- a/src/liblx/xml/test/TestXMLNamespaces.c
+++ b/src/liblx/xml/test/TestXMLNamespaces.c
@@ -113,7 +113,7 @@ START_TEST (test_XMLNamespaces_add1)
 
   int i = XMLNamespaces_add(NS, "http://test1.org/", "test1");
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLNamespaces_getLength(NS) == 1 );
   fail_unless( XMLNamespaces_isEmpty(NS) == 0 );
 
@@ -137,7 +137,7 @@ START_TEST (test_XMLNamespaces_add1)
   // add with existing prefix
   i = XMLNamespaces_add(NS, "http://test2.org/", "test1");
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLNamespaces_getLength(NS) == 1 );
   fail_unless( XMLNamespaces_isEmpty(NS) == 0 );
   
@@ -161,7 +161,7 @@ START_TEST (test_XMLNamespaces_add1)
   // add 
   i = XMLNamespaces_add(NS, "http://test.org/", "");
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLNamespaces_getLength(NS) == 2 );
   fail_unless( XMLNamespaces_isEmpty(NS) == 0 );
 
@@ -176,7 +176,7 @@ START_TEST (test_XMLNamespaces_add1)
   // add repeat with empty prefix
   i = XMLNamespaces_add(NS, "http://test3.org/", "");
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLNamespaces_getLength(NS) == 2 );
   fail_unless( XMLNamespaces_isEmpty(NS) == 0 );
   fail_unless( XMLNamespaces_getPrefix(NS, 1) == NULL );
@@ -190,7 +190,7 @@ START_TEST (test_XMLNamespaces_add1)
   // add sbml ns
   i = XMLNamespaces_add(NS, "http://www.sbml.org/sbml/level1", "");
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLNamespaces_getLength(NS) == 2 );
   fail_unless( XMLNamespaces_isEmpty(NS) == 0 );
   fail_unless( XMLNamespaces_getPrefix(NS, 1) == NULL );
@@ -205,7 +205,7 @@ START_TEST (test_XMLNamespaces_add1)
   // add a repeat of the sbml prefix ns
   i = XMLNamespaces_add(NS, "http://test_sbml_prefix/", "");
 
-  fail_unless( i == LIBSBXML_OPERATION_FAILED);
+  fail_unless( i == LIBLX_OPERATION_FAILED);
   fail_unless( XMLNamespaces_getLength(NS) == 2 );
   fail_unless( XMLNamespaces_isEmpty(NS) == 0 );
   fail_unless( XMLNamespaces_getPrefix(NS, 1) == NULL );
@@ -220,7 +220,7 @@ START_TEST (test_XMLNamespaces_add1)
   // add repeat sbml ns uri
   i = XMLNamespaces_add(NS, "http://www.sbml.org/sbml/level1", "newprefix");
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLNamespaces_getLength(NS) == 3 );
   fail_unless( XMLNamespaces_isEmpty(NS) == 0 );
   
@@ -240,7 +240,7 @@ START_TEST (test_XMLNamespaces_add1)
   // add repeat prefix
   i = XMLNamespaces_add(NS, "http://www.foo", "newprefix");
 
-  fail_unless( i == LIBSBXML_OPERATION_FAILED);
+  fail_unless( i == LIBLX_OPERATION_FAILED);
   fail_unless( XMLNamespaces_getLength(NS) == 3 );
   fail_unless( XMLNamespaces_isEmpty(NS) == 0 );
 
@@ -255,7 +255,7 @@ START_TEST (test_XMLNamespaces_add1)
   // change sbml ns uri - it will not do this
   i = XMLNamespaces_add(NS, "http://www.sbml.org/sbml/level2", "newprefix");
 
-  fail_unless( i == LIBSBXML_OPERATION_FAILED);
+  fail_unless( i == LIBLX_OPERATION_FAILED);
   fail_unless( XMLNamespaces_getLength(NS) == 3 );
   fail_unless( XMLNamespaces_isEmpty(NS) == 0 );
   test = XMLNamespaces_getPrefix(NS, 2);
@@ -479,22 +479,22 @@ START_TEST (test_XMLNamespaces_remove1)
   
   int i = XMLNamespaces_remove(NS, 4);
   
-  fail_unless (i == LIBSBXML_INDEX_EXCEEDS_SIZE );
+  fail_unless (i == LIBLX_INDEX_EXCEEDS_SIZE );
   fail_unless( XMLNamespaces_getLength(NS) == 2 );
   
   i = XMLNamespaces_removeByPrefix(NS, "test4");
 
-  fail_unless (i == LIBSBXML_INDEX_EXCEEDS_SIZE );
+  fail_unless (i == LIBLX_INDEX_EXCEEDS_SIZE );
   fail_unless( XMLNamespaces_getLength(NS) == 2 );
 
   i = XMLNamespaces_remove(NS, 1);
 
-  fail_unless (i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless (i == LIBLX_OPERATION_SUCCESS );
   fail_unless( XMLNamespaces_getLength(NS) == 1 );
 
   i = XMLNamespaces_removeByPrefix(NS, "test1");
 
-  fail_unless (i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless (i == LIBLX_OPERATION_SUCCESS );
   fail_unless( XMLNamespaces_getLength(NS) == 0 );
 }
 END_TEST
@@ -512,15 +512,15 @@ START_TEST (test_XMLNamespaces_clear)
 
   int i = XMLNamespaces_clear(NS);
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLNamespaces_getLength(NS) == 0 );
 }
 END_TEST
 
 START_TEST (test_XMLNamespaces_accessWithNULL)
 {
-  fail_unless( XMLNamespaces_add(NULL, NULL, NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless( XMLNamespaces_clear(NULL) == LIBSBXML_OPERATION_FAILED);
+  fail_unless( XMLNamespaces_add(NULL, NULL, NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless( XMLNamespaces_clear(NULL) == LIBLX_OPERATION_FAILED);
   fail_unless( XMLNamespaces_clone(NULL) == NULL);
 
   XMLNamespaces_free(NULL);
@@ -536,8 +536,8 @@ START_TEST (test_XMLNamespaces_accessWithNULL)
   fail_unless( XMLNamespaces_hasPrefix(NULL, NULL) == 0);
   fail_unless( XMLNamespaces_hasURI(NULL, NULL) == 0);
   fail_unless( XMLNamespaces_isEmpty(NULL) == 1);
-  fail_unless( XMLNamespaces_remove(NULL, 0) == LIBSBXML_INVALID_OBJECT);
-  fail_unless( XMLNamespaces_removeByPrefix(NULL, NULL) == LIBSBXML_INVALID_OBJECT);
+  fail_unless( XMLNamespaces_remove(NULL, 0) == LIBLX_INVALID_OBJECT);
+  fail_unless( XMLNamespaces_removeByPrefix(NULL, NULL) == LIBLX_INVALID_OBJECT);
 }
 END_TEST
 

--- a/src/liblx/xml/test/TestXMLNode_newSetters.c
+++ b/src/liblx/xml/test/TestXMLNode_newSetters.c
@@ -57,7 +57,7 @@ START_TEST (test_XMLNode_addChild1)
 
   int i = XMLNode_addChild(node, node2);
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless(XMLNode_getNumChildren(node) == 1);
 
   XMLNode_free(node);
@@ -75,7 +75,7 @@ START_TEST (test_XMLNode_addChild2)
 
   int i = XMLNode_addChild(node, node2);
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless(XMLNode_getNumChildren(node) == 1);
 
   XMLTriple_free(triple);
@@ -94,7 +94,7 @@ START_TEST (test_XMLNode_addChild3)
 
   int i = XMLNode_addChild(node, node2);
 
-  fail_unless( i == LIBSBXML_INVALID_XML_OPERATION);
+  fail_unless( i == LIBLX_INVALID_XML_OPERATION);
   fail_unless(XMLNode_getNumChildren(node) == 0);
 
   XMLTriple_free(triple);
@@ -116,7 +116,7 @@ START_TEST (test_XMLNode_removeChildren)
   fail_unless(XMLNode_getNumChildren(node) == 2);
 
   int i = XMLNode_removeChildren(node);
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless(XMLNode_getNumChildren(node) == 0);
 
   XMLNode_free(node);
@@ -140,59 +140,59 @@ START_TEST(test_XMLNode_removeAttributes)
                                              "http://name5.org/", "p5");
   int i = XMLNode_addAttr(node, "name1", "val1");
   
-  fail_unless(i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless(i == LIBLX_OPERATION_SUCCESS);
   fail_unless (XMLAttributes_getLength(XMLNode_getAttributes(node)) == 1);
 
   i = XMLNode_addAttrWithNS(node, "name2", "val2", 
                                              "http://name1.org/", "p1");
-  fail_unless(i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless(i == LIBLX_OPERATION_SUCCESS);
   fail_unless (XMLAttributes_getLength(XMLNode_getAttributes(node)) == 2);
 
   i = XMLNode_addAttrWithTriple(node, xt2, "val2");
   
-  fail_unless(i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless(i == LIBLX_OPERATION_SUCCESS);
   fail_unless (XMLAttributes_getLength(XMLNode_getAttributes(node)) == 3);
 
   i = XMLNode_addAttr(node, "name4", "val4");
 
-  fail_unless(i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless(i == LIBLX_OPERATION_SUCCESS);
   fail_unless (XMLAttributes_getLength(XMLNode_getAttributes(node)) == 4);
 
   i = XMLNode_removeAttr(node, 7);
 
-  fail_unless ( i == LIBSBXML_INDEX_EXCEEDS_SIZE );
+  fail_unless ( i == LIBLX_INDEX_EXCEEDS_SIZE );
 
   i = XMLNode_removeAttrByName(node, "name7");
 
-  fail_unless ( i == LIBSBXML_INDEX_EXCEEDS_SIZE );
+  fail_unless ( i == LIBLX_INDEX_EXCEEDS_SIZE );
 
   i = XMLNode_removeAttrByNS(node, "name7", "namespaces7");
 
-  fail_unless ( i == LIBSBXML_INDEX_EXCEEDS_SIZE );
+  fail_unless ( i == LIBLX_INDEX_EXCEEDS_SIZE );
 
   i = XMLNode_removeAttrByTriple(node, xt1);
 
-  fail_unless ( i == LIBSBXML_INDEX_EXCEEDS_SIZE );
+  fail_unless ( i == LIBLX_INDEX_EXCEEDS_SIZE );
   fail_unless (XMLAttributes_getLength(XMLNode_getAttributes(node)) == 4);
 
   i = XMLNode_removeAttr(node, 3);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS );
   fail_unless (XMLAttributes_getLength(XMLNode_getAttributes(node)) == 3);
 
   i = XMLNode_removeAttrByName(node, "name1");
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS );
   fail_unless (XMLAttributes_getLength(XMLNode_getAttributes(node)) == 2);
 
   i = XMLNode_removeAttrByNS(node, "name2", "http://name1.org/");
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS );
   fail_unless (XMLAttributes_getLength(XMLNode_getAttributes(node)) == 1);
 
   i = XMLNode_removeAttrByTriple(node, xt2);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS );
   fail_unless (XMLAttributes_getLength(XMLNode_getAttributes(node)) == 0);
 
   /*-- teardown --*/
@@ -220,27 +220,27 @@ START_TEST(test_XMLNode_clearAttributes)
                                              "http://name5.org/", "p5");
   int i = XMLNode_addAttr(node, "name1", "val1");
   
-  fail_unless(i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless(i == LIBLX_OPERATION_SUCCESS);
   fail_unless (XMLAttributes_getLength(XMLNode_getAttributes(node)) == 1);
 
   i = XMLNode_addAttrWithNS(node, "name2", "val2", 
                                              "http://name1.org/", "p1");
-  fail_unless(i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless(i == LIBLX_OPERATION_SUCCESS);
   fail_unless (XMLAttributes_getLength(XMLNode_getAttributes(node)) == 2);
 
   i = XMLNode_addAttrWithTriple(node, xt2, "val2");
   
-  fail_unless(i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless(i == LIBLX_OPERATION_SUCCESS);
   fail_unless (XMLAttributes_getLength(XMLNode_getAttributes(node)) == 3);
 
   i = XMLNode_addAttr(node, "name4", "val4");
 
-  fail_unless(i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless(i == LIBLX_OPERATION_SUCCESS);
   fail_unless (XMLAttributes_getLength(XMLNode_getAttributes(node)) == 4);
 
   i = XMLNode_clearAttributes(node);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS );
   fail_unless (XMLAttributes_getLength(XMLNode_getAttributes(node)) == 0);
 
   /*-- teardown --*/
@@ -265,37 +265,37 @@ START_TEST(test_XMLNode_removeNamespaces)
 
   int i = XMLNode_addNamespace(node, "http://test1.org/", "test1");
   
-  fail_unless(i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless(i == LIBLX_OPERATION_SUCCESS);
   nms = XMLNode_getNamespaces(node);
   fail_unless (XMLNamespaces_getLength(nms) == 1);
 
   i = XMLNode_addNamespace(node, "http://test2.org/", "test2");
   
-  fail_unless(i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless(i == LIBLX_OPERATION_SUCCESS);
   nms = XMLNode_getNamespaces(node);
   fail_unless (XMLNamespaces_getLength(nms) == 2);
 
   i = XMLNode_removeNamespace(node, 7);
 
-  fail_unless ( i == LIBSBXML_INDEX_EXCEEDS_SIZE );
+  fail_unless ( i == LIBLX_INDEX_EXCEEDS_SIZE );
   nms = XMLNode_getNamespaces(node);
   fail_unless (XMLNamespaces_getLength(nms) == 2);
 
   i = XMLNode_removeNamespaceByPrefix(node, "name7");
 
-  fail_unless ( i == LIBSBXML_INDEX_EXCEEDS_SIZE );
+  fail_unless ( i == LIBLX_INDEX_EXCEEDS_SIZE );
   nms = XMLNode_getNamespaces(node);
   fail_unless (XMLNamespaces_getLength(nms) == 2);
 
   i = XMLNode_removeNamespace(node, 0);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS );
   nms = XMLNode_getNamespaces(node);
   fail_unless (XMLNamespaces_getLength(nms) == 1);
 
   i = XMLNode_removeNamespaceByPrefix(node, "test2");
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS );
   nms = XMLNode_getNamespaces(node);
   fail_unless (XMLNamespaces_getLength(nms) == 0);
 
@@ -317,19 +317,19 @@ START_TEST(test_XMLNode_clearNamespaces)
 
   int i = XMLNode_addNamespace(node, "http://test1.org/", "test1");
   
-  fail_unless(i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless(i == LIBLX_OPERATION_SUCCESS);
   nms = XMLNode_getNamespaces(node);
   fail_unless (XMLNamespaces_getLength(nms) == 1);
 
   i = XMLNode_addNamespace(node, "http://test2.org/", "test2");
   
-  fail_unless(i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless(i == LIBLX_OPERATION_SUCCESS);
   nms = XMLNode_getNamespaces(node);
   fail_unless (XMLNamespaces_getLength(nms) == 2);
 
   i = XMLNode_clearNamespaces(node);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS );
   nms = XMLNode_getNamespaces(node);
   fail_unless (XMLNamespaces_getLength(nms) == 0);
 
@@ -341,14 +341,14 @@ END_TEST
 
 START_TEST(test_XMLNode_accessWithNULL)
 {
-  fail_unless( XMLNode_addAttr(NULL, NULL, NULL) == LIBSBXML_INVALID_OBJECT );
+  fail_unless( XMLNode_addAttr(NULL, NULL, NULL) == LIBLX_INVALID_OBJECT );
   fail_unless( XMLNode_addAttrWithNS(NULL, NULL, NULL, NULL, NULL) 
-    == LIBSBXML_INVALID_OBJECT );
-  fail_unless( XMLNode_addAttrWithTriple(NULL, NULL, NULL) == LIBSBXML_INVALID_OBJECT );
-  fail_unless( XMLNode_addChild(NULL, NULL) == LIBSBXML_INVALID_OBJECT );
-  fail_unless( XMLNode_addNamespace(NULL, NULL, NULL) == LIBSBXML_INVALID_OBJECT );
-  fail_unless( XMLNode_clearAttributes(NULL) == LIBSBXML_INVALID_OBJECT );
-  fail_unless( XMLNode_clearNamespaces(NULL) == LIBSBXML_INVALID_OBJECT );
+    == LIBLX_INVALID_OBJECT );
+  fail_unless( XMLNode_addAttrWithTriple(NULL, NULL, NULL) == LIBLX_INVALID_OBJECT );
+  fail_unless( XMLNode_addChild(NULL, NULL) == LIBLX_INVALID_OBJECT );
+  fail_unless( XMLNode_addNamespace(NULL, NULL, NULL) == LIBLX_INVALID_OBJECT );
+  fail_unless( XMLNode_clearAttributes(NULL) == LIBLX_INVALID_OBJECT );
+  fail_unless( XMLNode_clearNamespaces(NULL) == LIBLX_INVALID_OBJECT );
   fail_unless( XMLNode_clone(NULL) == NULL);
   fail_unless( XMLNode_convertStringToXMLNode(NULL, NULL) == NULL);
   fail_unless( XMLNode_convertXMLNodeToString(NULL) == NULL);
@@ -420,24 +420,24 @@ START_TEST(test_XMLNode_accessWithNULL)
   fail_unless( XMLNode_isStart(NULL) == 0);
   fail_unless( XMLNode_isText(NULL) == 0);
   
-  fail_unless( XMLNode_removeAttr(NULL, 0) == LIBSBXML_INVALID_OBJECT);
-  fail_unless( XMLNode_removeAttrByName(NULL, NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless( XMLNode_removeAttrByNS(NULL, NULL, NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless( XMLNode_removeAttrByTriple(NULL, NULL) == LIBSBXML_INVALID_OBJECT);
+  fail_unless( XMLNode_removeAttr(NULL, 0) == LIBLX_INVALID_OBJECT);
+  fail_unless( XMLNode_removeAttrByName(NULL, NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless( XMLNode_removeAttrByNS(NULL, NULL, NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless( XMLNode_removeAttrByTriple(NULL, NULL) == LIBLX_INVALID_OBJECT);
   
   fail_unless( XMLNode_removeChild(NULL, 0) == NULL);
-  fail_unless( XMLNode_removeChildren(NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless( XMLNode_removeNamespace(NULL, 0) == LIBSBXML_INVALID_OBJECT);
-  fail_unless( XMLNode_removeNamespaceByPrefix(NULL, NULL) == LIBSBXML_INVALID_OBJECT);
+  fail_unless( XMLNode_removeChildren(NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless( XMLNode_removeNamespace(NULL, 0) == LIBLX_INVALID_OBJECT);
+  fail_unless( XMLNode_removeNamespaceByPrefix(NULL, NULL) == LIBLX_INVALID_OBJECT);
   
-  fail_unless( XMLNode_setAttributes(NULL, NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless( XMLNode_setEnd(NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless( XMLNode_setEOF(NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless( XMLNode_setNamespaces(NULL, NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless( XMLNode_setTriple(NULL, NULL) == LIBSBXML_INVALID_OBJECT);
+  fail_unless( XMLNode_setAttributes(NULL, NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless( XMLNode_setEnd(NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless( XMLNode_setEOF(NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless( XMLNode_setNamespaces(NULL, NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless( XMLNode_setTriple(NULL, NULL) == LIBLX_INVALID_OBJECT);
   
   fail_unless( XMLNode_toXMLString(NULL) == NULL);
-  fail_unless( XMLNode_unsetEnd(NULL) == LIBSBXML_INVALID_OBJECT);
+  fail_unless( XMLNode_unsetEnd(NULL) == LIBLX_INVALID_OBJECT);
   
     
 }

--- a/src/liblx/xml/test/TestXMLToken.c
+++ b/src/liblx/xml/test/TestXMLToken.c
@@ -879,13 +879,13 @@ END_TEST
 
 START_TEST(test_XMLToken_accessWithNULL)
 {
-  fail_unless (XMLToken_addAttr(NULL, NULL, NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless (XMLToken_addAttrWithNS(NULL, NULL, NULL, NULL, NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless (XMLToken_addAttrWithTriple(NULL, NULL, NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless (XMLToken_addNamespace(NULL, NULL, NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless (XMLToken_append(NULL, NULL) == LIBSBXML_OPERATION_FAILED);
-  fail_unless (XMLToken_clearAttributes(NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless (XMLToken_clearNamespaces(NULL) == LIBSBXML_INVALID_OBJECT);
+  fail_unless (XMLToken_addAttr(NULL, NULL, NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless (XMLToken_addAttrWithNS(NULL, NULL, NULL, NULL, NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless (XMLToken_addAttrWithTriple(NULL, NULL, NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless (XMLToken_addNamespace(NULL, NULL, NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless (XMLToken_append(NULL, NULL) == LIBLX_OPERATION_FAILED);
+  fail_unless (XMLToken_clearAttributes(NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless (XMLToken_clearNamespaces(NULL) == LIBLX_INVALID_OBJECT);
   fail_unless (XMLToken_clone(NULL) == NULL);
   fail_unless (XMLToken_createWithTriple(NULL) == NULL);
   fail_unless (XMLToken_createWithTripleAttr(NULL, NULL) == NULL);
@@ -935,21 +935,21 @@ START_TEST(test_XMLToken_accessWithNULL)
   fail_unless (XMLToken_isStart(NULL) == 0);
   fail_unless (XMLToken_isText(NULL) == 0);
   
-  fail_unless (XMLToken_removeAttr(NULL, 0) == LIBSBXML_INVALID_OBJECT);
-  fail_unless (XMLToken_removeAttrByName(NULL, NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless (XMLToken_removeAttrByNS(NULL, NULL, NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless (XMLToken_removeAttrByTriple(NULL, NULL) == LIBSBXML_INVALID_OBJECT);
+  fail_unless (XMLToken_removeAttr(NULL, 0) == LIBLX_INVALID_OBJECT);
+  fail_unless (XMLToken_removeAttrByName(NULL, NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless (XMLToken_removeAttrByNS(NULL, NULL, NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless (XMLToken_removeAttrByTriple(NULL, NULL) == LIBLX_INVALID_OBJECT);
   
-  fail_unless (XMLToken_removeNamespace(NULL, 0) == LIBSBXML_INVALID_OBJECT);
-  fail_unless (XMLToken_removeNamespaceByPrefix(NULL, NULL) == LIBSBXML_INVALID_OBJECT);
+  fail_unless (XMLToken_removeNamespace(NULL, 0) == LIBLX_INVALID_OBJECT);
+  fail_unless (XMLToken_removeNamespaceByPrefix(NULL, NULL) == LIBLX_INVALID_OBJECT);
   
-  fail_unless (XMLToken_setAttributes(NULL, NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless (XMLToken_setEnd(NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless (XMLToken_setEOF(NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless (XMLToken_setNamespaces(NULL, NULL) == LIBSBXML_INVALID_OBJECT);
-  fail_unless (XMLToken_setTriple(NULL, NULL) == LIBSBXML_INVALID_OBJECT);
+  fail_unless (XMLToken_setAttributes(NULL, NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless (XMLToken_setEnd(NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless (XMLToken_setEOF(NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless (XMLToken_setNamespaces(NULL, NULL) == LIBLX_INVALID_OBJECT);
+  fail_unless (XMLToken_setTriple(NULL, NULL) == LIBLX_INVALID_OBJECT);
   
-  fail_unless (XMLToken_unsetEnd(NULL) == LIBSBXML_INVALID_OBJECT);
+  fail_unless (XMLToken_unsetEnd(NULL) == LIBLX_INVALID_OBJECT);
 }
 END_TEST
 

--- a/src/liblx/xml/test/TestXMLToken_newSetters.c
+++ b/src/liblx/xml/test/TestXMLToken_newSetters.c
@@ -71,7 +71,7 @@ START_TEST(test_XMLToken_newSetters_setAttributes1)
 
   int i = XMLToken_setAttributes(token, nattr);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS);
   fail_unless(XMLToken_isAttributesEmpty(token)   == 0 );
 
   /*-- teardown --*/
@@ -101,13 +101,13 @@ START_TEST(test_XMLToken_newSetters_setAttributes2)
   /*-- test of setting attributes with NULL value -- */
   i = XMLToken_setAttributes(token, NULL);
 
-  fail_unless ( i == LIBSBXML_INVALID_OBJECT);
+  fail_unless ( i == LIBLX_INVALID_OBJECT);
 
   /*-- test of setting attributes -- */
 
   i = XMLToken_setAttributes(token, nattr);
 
-  fail_unless ( i == LIBSBXML_INVALID_XML_OPERATION);
+  fail_unless ( i == LIBLX_INVALID_XML_OPERATION);
   fail_unless(XMLToken_isAttributesEmpty(token)   == 1 );
 
 
@@ -138,12 +138,12 @@ START_TEST(test_XMLToken_newSetters_clearAttributes1)
 
   int i = XMLToken_setAttributes(token, nattr);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS);
   fail_unless(XMLToken_isAttributesEmpty(token)   == 0 );
 
   i = XMLToken_clearAttributes(token);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS);
   fail_unless(XMLToken_isAttributesEmpty(token)   == 1 );
   /*-- teardown --*/
 
@@ -171,7 +171,7 @@ START_TEST(test_XMLToken_newSetters_addAttributes1)
 
   int i = XMLToken_addAttr(token, "name1", "val1");
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless( i == LIBLX_OPERATION_SUCCESS );
   fail_unless( XMLToken_getAttributesLength(token) == 1 );
   fail_unless( XMLToken_isAttributesEmpty(token)   == 0 );
 
@@ -187,7 +187,7 @@ START_TEST(test_XMLToken_newSetters_addAttributes1)
   i = XMLToken_addAttrWithNS(token, "name2", "val2", 
                                              "http://name1.org/", "p1");
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless( i == LIBLX_OPERATION_SUCCESS );
   fail_unless( XMLToken_getAttributesLength(token) == 2 );
   fail_unless( XMLToken_isAttributesEmpty(token)   == 0 );
 
@@ -210,7 +210,7 @@ START_TEST(test_XMLToken_newSetters_addAttributes1)
 
   i = XMLToken_addAttrWithTriple(token, xt2, "val2");
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless( i == LIBLX_OPERATION_SUCCESS );
   fail_unless( XMLToken_getAttributesLength(token) == 3 );
   fail_unless( XMLToken_isAttributesEmpty(token)   == 0 );
 
@@ -254,20 +254,20 @@ START_TEST(test_XMLToken_newSetters_addAttributes2)
 
   int i = XMLToken_addAttr(token, "name1", "val1");
 
-  fail_unless( i == LIBSBXML_INVALID_XML_OPERATION );
+  fail_unless( i == LIBLX_INVALID_XML_OPERATION );
   fail_unless( XMLToken_getAttributesLength(token) == 0 );
   fail_unless( XMLToken_isAttributesEmpty(token)   == 1 );
 
   i = XMLToken_addAttrWithNS(token, "name2", "val2", 
                                              "http://name1.org/", "p1");
 
-  fail_unless( i == LIBSBXML_INVALID_XML_OPERATION );
+  fail_unless( i == LIBLX_INVALID_XML_OPERATION );
   fail_unless( XMLToken_getAttributesLength(token) == 0 );
   fail_unless( XMLToken_isAttributesEmpty(token)   == 1 );
 
   i = XMLToken_addAttrWithTriple(token, xt2, "val2");
 
-  fail_unless( i == LIBSBXML_INVALID_XML_OPERATION );
+  fail_unless( i == LIBLX_INVALID_XML_OPERATION );
   fail_unless( XMLToken_getAttributesLength(token) == 0 );
   fail_unless( XMLToken_isAttributesEmpty(token)   == 1 );
 
@@ -297,7 +297,7 @@ START_TEST(test_XMLToken_newSetters_setNamespaces1)
 
   int i =   XMLToken_setNamespaces(token, ns);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLToken_getNamespacesLength(token) == 1 );
   fail_unless( XMLToken_isNamespacesEmpty(token)   == 0 );  
 
@@ -330,13 +330,13 @@ START_TEST(test_XMLToken_newSetters_setNamespaces2)
   /*-- test of setting namespaces with NULL value -- */
   i = XMLToken_setNamespaces(token, NULL);
 
-  fail_unless ( i == LIBSBXML_INVALID_OBJECT);
+  fail_unless ( i == LIBLX_INVALID_OBJECT);
 
 
   /*-- test of setting namespaces -- */
   i =   XMLToken_setNamespaces(token, ns);
 
-  fail_unless ( i == LIBSBXML_INVALID_XML_OPERATION);
+  fail_unless ( i == LIBLX_INVALID_XML_OPERATION);
   fail_unless( XMLToken_getNamespacesLength(token) == 0 );
   fail_unless( XMLToken_isNamespacesEmpty(token)   == 1 );  
 
@@ -366,13 +366,13 @@ START_TEST(test_XMLToken_newSetters_clearNamespaces1)
 
   int i =   XMLToken_setNamespaces(token, ns);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLToken_getNamespacesLength(token) == 1 );
   fail_unless( XMLToken_isNamespacesEmpty(token)   == 0 );  
 
   i = XMLToken_clearNamespaces(token);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLToken_getNamespacesLength(token) == 0 );
   fail_unless( XMLToken_isNamespacesEmpty(token)   == 1 );  
 
@@ -400,7 +400,7 @@ START_TEST(test_XMLToken_newSetters_addNamespaces1)
   /*-- test of setting namespaces -- */
   int i =  XMLToken_addNamespace(token, "http://test1.org/", "test1");
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLToken_getNamespacesLength(token) == 1 );
   fail_unless( XMLToken_isNamespacesEmpty(token)   == 0 );  
 
@@ -426,7 +426,7 @@ START_TEST(test_XMLToken_newSetters_addNamespaces2)
   /*-- test of setting namespaces -- */
   int i =   XMLToken_addNamespace(token, "http://test1.org/", "test1");
 
-  fail_unless ( i == LIBSBXML_INVALID_XML_OPERATION);
+  fail_unless ( i == LIBLX_INVALID_XML_OPERATION);
   fail_unless( XMLToken_getNamespacesLength(token) == 0 );
   fail_unless( XMLToken_isNamespacesEmpty(token)   == 1 );  
 
@@ -448,7 +448,7 @@ START_TEST(test_XMLToken_newSetters_setTriple1)
   /*-- test of setting triple -- */
   int i =   XMLToken_setTriple(token, triple);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( !strcmp(XMLToken_getName(token), "test") );
 
   /*-- teardown --*/
@@ -471,13 +471,13 @@ START_TEST(test_XMLToken_newSetters_setTriple2)
   /*-- test of setting triple with NULL value -- */
   i = XMLToken_setTriple(token, NULL);
 
-  fail_unless ( i == LIBSBXML_INVALID_OBJECT);
+  fail_unless ( i == LIBLX_INVALID_OBJECT);
 
   
   /*-- test of setting triple -- */
   i =   XMLToken_setTriple(token, triple);
 
-  fail_unless ( i == LIBSBXML_INVALID_XML_OPERATION);
+  fail_unless ( i == LIBLX_INVALID_XML_OPERATION);
 
   /*-- teardown --*/
 
@@ -497,12 +497,12 @@ START_TEST(test_XMLToken_newSetters_setEnd)
   /*-- test of setting end -- */
   int i =   XMLToken_setEnd(token);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLToken_isEnd(token) == 1 );
 
   i =   XMLToken_unsetEnd(token);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLToken_isEnd(token) == 0 );
   /*-- teardown --*/
 
@@ -521,7 +521,7 @@ START_TEST(test_XMLToken_newSetters_setEOF)
   /*-- test of setting eof -- */
   int i =   XMLToken_setEOF(token);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLToken_isEnd(token) == 0 );
   fail_unless( XMLToken_isStart(token) == 0 );
   fail_unless( XMLToken_isText(token) == 0 );
@@ -555,39 +555,39 @@ START_TEST(test_XMLToken_newSetters_removeAttributes1)
 
   i = XMLToken_removeAttr(token, 7);
 
-  fail_unless ( i == LIBSBXML_INDEX_EXCEEDS_SIZE );
+  fail_unless ( i == LIBLX_INDEX_EXCEEDS_SIZE );
 
   i = XMLToken_removeAttrByName(token, "name7");
 
-  fail_unless ( i == LIBSBXML_INDEX_EXCEEDS_SIZE );
+  fail_unless ( i == LIBLX_INDEX_EXCEEDS_SIZE );
 
   i = XMLToken_removeAttrByNS(token, "name7", "namespaces7");
 
-  fail_unless ( i == LIBSBXML_INDEX_EXCEEDS_SIZE );
+  fail_unless ( i == LIBLX_INDEX_EXCEEDS_SIZE );
 
   i = XMLToken_removeAttrByTriple(token, xt1);
 
-  fail_unless ( i == LIBSBXML_INDEX_EXCEEDS_SIZE );
+  fail_unless ( i == LIBLX_INDEX_EXCEEDS_SIZE );
   fail_unless (XMLAttributes_getLength(XMLToken_getAttributes(token)) == 4);
 
   i = XMLToken_removeAttr(token, 3);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS );
   fail_unless (XMLAttributes_getLength(XMLToken_getAttributes(token)) == 3);
 
   i = XMLToken_removeAttrByName(token, "name1");
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS );
   fail_unless (XMLAttributes_getLength(XMLToken_getAttributes(token)) == 2);
 
   i = XMLToken_removeAttrByNS(token, "name2", "http://name1.org/");
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS );
   fail_unless (XMLAttributes_getLength(XMLToken_getAttributes(token)) == 1);
 
   i = XMLToken_removeAttrByTriple(token, xt2);
 
-  fail_unless ( i == LIBSBXML_OPERATION_SUCCESS );
+  fail_unless ( i == LIBLX_OPERATION_SUCCESS );
   fail_unless (XMLAttributes_getLength(XMLToken_getAttributes(token)) == 0);
 
   /*-- teardown --*/
@@ -613,12 +613,12 @@ START_TEST (test_XMLToken_newSetters_removeNamespaces)
   
   int i = XMLToken_removeNamespace(token, 4);
   
-  fail_unless( i == LIBSBXML_INDEX_EXCEEDS_SIZE);
+  fail_unless( i == LIBLX_INDEX_EXCEEDS_SIZE);
   fail_unless( XMLToken_getNamespacesLength(token) == 1 );
   
   i = XMLToken_removeNamespace(token, 0);
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLToken_getNamespacesLength(token) == 0 );
 
   XMLToken_free(token);
@@ -640,12 +640,12 @@ START_TEST (test_XMLToken_newSetters_removeNamespaces1)
   
   int i = XMLToken_removeNamespaceByPrefix(token, "test2");
   
-  fail_unless( i == LIBSBXML_INDEX_EXCEEDS_SIZE);
+  fail_unless( i == LIBLX_INDEX_EXCEEDS_SIZE);
   fail_unless( XMLToken_getNamespacesLength(token) == 1 );
   
   i = XMLToken_removeNamespaceByPrefix(token, "test1");
 
-  fail_unless( i == LIBSBXML_OPERATION_SUCCESS);
+  fail_unless( i == LIBLX_OPERATION_SUCCESS);
   fail_unless( XMLToken_getNamespacesLength(token) == 0 );
 
   XMLToken_free(token);


### PR DESCRIPTION
## Description
Return value macros were still prefixed by LIBSBXML. Replace these by LIBLX.

## Motivation and Context
More LibSBXML name clean up.

## Types of changes
Renamery.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

